### PR TITLE
hopefully *FIXED* that weird span bug

### DIFF
--- a/src/content-scripts/scraper.js
+++ b/src/content-scripts/scraper.js
@@ -360,9 +360,9 @@ function main() {
                     page.push(text);
 
                     // mirror state;
-
-                    let elements = child.querySelectorAll("span");
-                    // get last element
+					// get the children from the most specific div possible. It is always the LAST child of the profile pic container.
+                    let elements = child.children[0].children[0].querySelectorAll("span");
+                    // get last element because the first span in humans deals with profile pics
                     let spanText = elements[elements.length - 1]?.innerHTML; // html instead of text because it sometimes hides
                     if (human) {
                         // because there are now two spans being used for other stuff, but only for humans
@@ -370,6 +370,7 @@ function main() {
                     }
 
                     let leafIndex = 0;
+					// remember that sometimes spanText is undefined, and that is normal because there isn't always a branch
                     if (spanText) {
                         let spanNumber = Number(spanText.split("/")[0]);
                         // sometimes spanText trawls up "!" that comes from content warning policy; just ignore that.


### PR DESCRIPTION
One line of code and it's fixed, as usual...
As it turns out, not having a more robust way to query `<span>` text has come back to haunt us.

Did some testing with sample code; the reason I wasn't getting the bug was because I almost never ask ChatGPT to write code, and the bug can only be reproduced with code (since `<span>` is hidden in *that*) and plus, the bug will only trigger IF the code ends with a highlighted number that can be coerced to a `Number()`, which is highly unlikely.

The fix was to make the query more specific, instead of lazily querying the body, we query the most specific container that might or might not contain said `<span>` indicating branch status.

*Should* be fixed, and if it comes back again, either it means I made a silly mistake or OpenAI changed their layout.